### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: [ 'v*.*.*' ]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cjmalloy/jasper-ssh/security/code-scanning/1](https://github.com/cjmalloy/jasper-ssh/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow uses the `actions/create-release@v1` action to create a draft release, it requires `contents: write` permissions. We will set this permission explicitly at the workflow level to ensure that no unnecessary permissions are granted. This change will be made at the root of the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
